### PR TITLE
Dev/oeun

### DIFF
--- a/src/app/api/moims/[id]/route.ts
+++ b/src/app/api/moims/[id]/route.ts
@@ -65,7 +65,7 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
     category: moimDataOrigin.moimType,
     status: moimDataOrigin.status,
     master_email: existingMoim?.master_email,
-    images: [],
+    images: existingMoim?.images,
     updated_at: new Date().toISOString(),
   };
 

--- a/src/app/api/moims/[id]/route.ts
+++ b/src/app/api/moims/[id]/route.ts
@@ -53,6 +53,19 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
     return NextResponse.json({ message: existingMoimError?.message }, { status: 401 });
   }
 
+  // 현재 시간 가져오기 (UTC)
+  const now = new Date().toISOString();
+
+  // 상태 결정 로직
+  let status: 'RECRUIT' | 'PROGRESS' | 'END';
+  if (now < moimDataOrigin.recruitmentDeadline) {
+    status = 'RECRUIT';
+  } else if (now >= moimDataOrigin.startDate && now <= moimDataOrigin.endDate) {
+    status = 'PROGRESS';
+  } else {
+    status = 'END';
+  }
+
   const moimData: Partial<TMoims> = {
     title: moimDataOrigin.title,
     content: moimDataOrigin.content,
@@ -63,7 +76,7 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
     min_participants: moimDataOrigin.minParticipants,
     max_participants: moimDataOrigin.maxParticipants,
     category: moimDataOrigin.moimType,
-    status: moimDataOrigin.status,
+    status,
     master_email: existingMoim?.master_email,
     images: existingMoim?.images,
     updated_at: new Date().toISOString(),

--- a/src/app/api/moims/route.ts
+++ b/src/app/api/moims/route.ts
@@ -137,7 +137,7 @@ export async function POST(req: NextRequest) {
     category: moimDataOrigin.moimType,
     status: moimDataOrigin.status,
     master_email: user?.email,
-    images: [],
+    images: null,
   };
 
   if (!moimDataString) {

--- a/src/app/api/moims/route.ts
+++ b/src/app/api/moims/route.ts
@@ -125,6 +125,23 @@ export async function POST(req: NextRequest) {
   const moimImageFile = formData.get('moim_image') as File;
   const moimDataOrigin = JSON.parse(moimDataString as string);
 
+  if (!moimDataString) {
+    return NextResponse.json({ message: '모임 데이터가 없어요' }, { status: 404 });
+  }
+
+  // 현재 시간 가져오기 (UTC)
+  const now = new Date().toISOString();
+
+  // 상태 결정 로직
+  let status: 'RECRUIT' | 'PROGRESS' | 'END';
+  if (now < moimDataOrigin.recruitmentDeadline) {
+    status = 'RECRUIT';
+  } else if (now >= moimDataOrigin.startDate && now <= moimDataOrigin.endDate) {
+    status = 'PROGRESS';
+  } else {
+    status = 'END';
+  }
+
   const moimData: Partial<TMoims> = {
     title: moimDataOrigin.title,
     content: moimDataOrigin.content,
@@ -135,18 +152,10 @@ export async function POST(req: NextRequest) {
     min_participants: moimDataOrigin.minParticipants,
     max_participants: moimDataOrigin.maxParticipants,
     category: moimDataOrigin.moimType,
-    status: moimDataOrigin.status,
+    status,
     master_email: user?.email,
     images: null,
   };
-
-  if (!moimDataString) {
-    return NextResponse.json({ message: '모임 데이터가 없어요' }, { status: 404 });
-  }
-
-  if (!moimImageFile && !moimData) {
-    return NextResponse.json({ message: '모임 데이터가 없어요' }, { status: 404 });
-  }
 
   // 이미지 파일이 있는 경우
   if (moimImageFile) {


### PR DESCRIPTION
# Pull Request

## 📌 제목
모임 상태 계산 자동화

---

## ✏️ 작업 내용 요약
> 모임 생성, 수정시 모임의 상태(모집중,진행중,종료)를 서버에서 계산하도록 하였습니다.

## 📝 작업 내용 설명
> 모임 생성, 수정시 현재는 모집의 상태를 클라이언트에서 보내준 값으로만 적용하고 있는데,
> 이 경우 유저가 실수로 잘못 선택시 보정해줄 방법이 없다고 생각되어,
> route handler 에서 모집 상태를 다시한번 계산하도록 하였습니다.

---

## ✅ 체크리스트
- [ ] 관련 Issue가 연결되었나요? (예: #123)
- [x] 새로운 기능이 문서화되었나요?
- [x] 작성한 코드가 로컬 환경에서 정상 동작하나요?

---

## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
