### PR TITLE
fix: access_token 만료에 따른 인증인가 에러 케이스 수정

### DIFF
--- a/src/apis/auth/auth.api.ts
+++ b/src/apis/auth/auth.api.ts
@@ -24,9 +24,8 @@ export const deleteSignOut = () => {
   return api.delete<TSignOutResponse, TSignOutResponse>(url);
 };
 
-export const getMe = async (jwt?: string) => {
-  let url = '/api/auth/me';
-  if (jwt) url = `/api/auth/me?jwt=${jwt}`;
+export const getMe = async () => {
+  const url = '/api/auth/me';
   return await api.get<TMe, TMe>(url);
 };
 

--- a/src/app/api/auth/confirm/route.ts
+++ b/src/app/api/auth/confirm/route.ts
@@ -20,32 +20,6 @@ export async function GET(request: NextRequest) {
   // console.log('타입 =>', type);
   // console.log('다음 주소 =>', next);
 
-  // 패스워드 변경 플로우 인데 만약에 로그인 중이면 로그아웃 시킬것
-  // let user: User | null;
-  // let error: AuthError | null;
-  // if (token) {
-  //   ({
-  //     data: { user },
-  //     error,
-  //   } = await supabase.auth.getUser(token));
-  // } else {
-  //   ({
-  //     data: { user },
-  //     error,
-  //   } = await supabase.auth.getUser());
-  // }
-
-  // if (error) {
-  //   return NextResponse.json({ message: '문제가 발생했습니다' }, { status: 500 });
-  // }
-
-  // if (user) {
-  //   const { error: logoutError } = await supabase.auth.signOut();
-  //   if (logoutError) {
-  //     return NextResponse.json({ message: '로그아웃에 실패했습니다' }, { status: 500 });
-  //   }
-  // }
-
   if (token_hash && type) {
     const {
       data: { user, session },

--- a/src/app/api/auth/getUser.ts
+++ b/src/app/api/auth/getUser.ts
@@ -1,0 +1,175 @@
+'use server';
+
+import { deleteCookie, setCookie } from '@/utils/auth/auth-server.util';
+import { SupabaseClient, User } from '@supabase/supabase-js';
+import { cookies, headers } from 'next/headers';
+
+type GetUserResponse =
+  | {
+      isSuccess: true;
+      message: string;
+      user: User;
+      status: 200;
+    }
+  | {
+      isSuccess: false;
+      message: string;
+      user: null;
+      status: number;
+    };
+
+export async function getUser(supabase: SupabaseClient): Promise<GetUserResponse> {
+  const cookieStore = await cookies();
+  const authorization = (await headers()).get('authorization');
+
+  if (!authorization) {
+    return {
+      isSuccess: false,
+      message: 'Authorization header가 없습니다',
+      user: null,
+      status: 401,
+    };
+  }
+
+  const token = authorization?.split(' ')[1] ?? null;
+  const refreshToken = cookieStore.get('refresh_token')?.value ?? null;
+
+  if (!refreshToken) {
+    return {
+      isSuccess: false,
+      message: 'Refresh token이 없습니다',
+      user: null,
+      status: 401,
+    };
+  }
+
+  // 1. 우선 jwt 토큰 없이 유저 정보 조회 시도
+  let {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  // console.log('error ===>', error);
+
+  if (error && error.message === 'Unauthorized') {
+    return {
+      isSuccess: false,
+      message: '인증되지 않은 사용자입니다',
+      user: null,
+      status: 401,
+    };
+  }
+
+  // 2. 토큰 없이 시도했는데, 세션이 유효하지 않은 경우
+  if (error && error.message === 'Auth session missing!') {
+    deleteCookie('access_token');
+    deleteCookie('refresh_token');
+    deleteCookie('sb-kabbnwozubbpbafvlolf-auth-token-code-verifier');
+
+    // 3. 토큰을 사용해서 다시 시도
+    ({
+      data: { user },
+      error,
+    } = await supabase.auth.getUser(token));
+  }
+
+  // 4. 토큰을 사용해서 시도했는데 토큰이 유효하지 않은 경우, 세션 갱신 시도
+  if (error && error?.code === 'bad_jwt') {
+    const { data: refreshData, error: refreshError } = await supabase.auth.refreshSession({
+      refresh_token: refreshToken,
+    });
+
+    if (refreshError) {
+      return {
+        isSuccess: false,
+        message: refreshError?.message,
+        user: null,
+        status: 500,
+      };
+    }
+
+    if (!refreshData?.session?.access_token || !refreshData?.session?.refresh_token) {
+      return {
+        isSuccess: false,
+        message: 'Refresh token이 유효하지 않습니다',
+        user: null,
+        status: 401,
+      };
+    }
+
+    const { data: userData, error: userError } = await supabase.auth.getUser(
+      refreshData.session.access_token,
+    );
+
+    if (userError) {
+      return {
+        isSuccess: false,
+        message: userError?.message,
+        user: null,
+        status: 500,
+      };
+    }
+
+    if (!userData.user) {
+      return {
+        isSuccess: false,
+        message: '로그인 후 이용해주세요',
+        user: null,
+        status: 401,
+      };
+    }
+
+    // 5. 세션 갱신 성공 시 쿠키 설정 및 유저 정보 반환
+    user = userData.user;
+
+    setCookie({
+      name: 'access_token',
+      value: refreshData?.session?.access_token,
+      maxAge: 60 * 60,
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+    });
+    setCookie({
+      name: 'refresh_token',
+      value: refreshData?.session?.refresh_token,
+      maxAge: 60 * 60 * 24 * 30,
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+    });
+
+    return {
+      isSuccess: true,
+      message: 'Refresh token 갱신 성공',
+      user,
+      status: 200,
+    };
+  }
+
+  if (error) {
+    return {
+      isSuccess: false,
+      message: error?.message,
+      user: null,
+      status: 500,
+    };
+  }
+
+  if (!user) {
+    return {
+      isSuccess: false,
+      message: '로그인 후 이용해주세요',
+      user: null,
+      status: 401,
+    };
+  }
+
+  // 마지막 return 문은 상단에서 error에 걸리지 않았을 때 === jwt 없이 getUser 성공했다는 뜻
+  return {
+    isSuccess: true,
+    message: '사용자 정보 조회 성공',
+    user,
+    status: 200,
+  };
+}

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,58 +1,19 @@
 import { TMe, TPutMeInputs } from '@/types/auth/auth.type';
-import { deleteCookie } from '@/utils/auth/auth-server.util';
 import convertToWebP from '@/utils/common/converToWebp';
 import { createClient } from '@/utils/supabase/server';
-import { AuthError, PostgrestError, User } from '@supabase/supabase-js';
-import { cookies, headers } from 'next/headers';
+import { PostgrestError } from '@supabase/supabase-js';
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
+import { getUser } from '../getUser';
 
-export async function GET(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
-  const jwt = searchParams.get('jwt');
+export async function GET() {
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
-  const authorization = (await headers()).get('authorization');
-  const token = authorization?.split(' ')[1] ?? null;
 
-  const jwtToken = jwt ?? token;
+  const { isSuccess, message, user, status } = await getUser(supabase);
 
-  let user: User | null;
-  let error: AuthError | null;
-  if (jwtToken) {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser(jwtToken));
-  } else {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser());
-  }
-
-  if (error) {
-    if (error.message === 'Auth session missing!') {
-      deleteCookie('access_token');
-      deleteCookie('refresh_token');
-      deleteCookie('sb-kabbnwozubbpbafvlolf-auth-token-code-verifier');
-
-      return NextResponse.json(
-        { message: '쿠키, 토큰이 유효하지 않습니다. 다시 로그인 하세요.' },
-        {
-          status: 401,
-        },
-      );
-    }
-
-    console.log('getUser error from route handler ====>', error);
-
-    if (error.message === 'Unauthorized') {
-      return NextResponse.json({ message: '인증되지 않은 사용자입니다' }, { status: 401 });
-    }
-    return NextResponse.json({ message: error?.message }, { status: 401 });
-  }
-  if (!user) {
-    return NextResponse.json({ message: '로그인된 사용자가 없습니다' }, { status: 404 });
+  if (!isSuccess) {
+    return NextResponse.json({ message }, { status });
   }
 
   const { data: me, error: meError }: { data: TMe | null; error: PostgrestError | null } =
@@ -98,28 +59,10 @@ export async function PUT(req: NextRequest) {
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
 
-  const authorization = (await headers()).get('authorization');
-  const token = authorization?.split(' ')[1] ?? null;
+  const { isSuccess, message, user, status: userStatus } = await getUser(supabase);
 
-  let user: User | null;
-  let error: AuthError | null;
-  if (token) {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser(token));
-  } else {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser());
-  }
-
-  if (error) {
-    return NextResponse.json({ message: error?.message }, { status: 401 });
-  }
-  if (!user) {
-    return NextResponse.json({ message: '로그인된 사용자가 없습니다' }, { status: 404 });
+  if (!isSuccess) {
+    return NextResponse.json({ message }, { status: userStatus });
   }
 
   const { data: userData, error: userError }: { data: TMe | null; error: PostgrestError | null } =

--- a/src/app/api/moims/[id]/join/route.ts
+++ b/src/app/api/moims/[id]/join/route.ts
@@ -1,37 +1,20 @@
+import { getUser } from '@/app/api/auth/getUser';
 import { TMe } from '@/types/auth/auth.type';
 import { mapMoimsToClient } from '@/utils/common/mapMoims';
 import { createClient } from '@/utils/supabase/server';
-import { AuthError, PostgrestError, User } from '@supabase/supabase-js';
-import { cookies, headers } from 'next/headers';
+import { PostgrestError } from '@supabase/supabase-js';
+import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const id = (await params).id;
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
-  const authorization = (await headers()).get('authorization');
-  const token = authorization?.split(' ')[1] ?? null;
 
-  let user: User | null;
-  let error: AuthError | null;
-  if (token) {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser(token));
-  } else {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser());
-  }
+  const { isSuccess, message, user, status: userStatus } = await getUser(supabase);
 
-  if (error) {
-    return NextResponse.json({ message: error?.message }, { status: 401 });
-  }
-
-  if (!user) {
-    return NextResponse.json({ message: '로그인 후 이용해주세요' }, { status: 401 });
+  if (!isSuccess) {
+    return NextResponse.json({ message }, { status: userStatus });
   }
 
   const {

--- a/src/app/api/moims/[id]/like/route.ts
+++ b/src/app/api/moims/[id]/like/route.ts
@@ -1,36 +1,18 @@
+import { getUser } from '@/app/api/auth/getUser';
 import { mapMoimsToClient } from '@/utils/common/mapMoims';
 import { createClient } from '@/utils/supabase/server';
-import { AuthError, User } from '@supabase/supabase-js';
-import { cookies, headers } from 'next/headers';
+import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const id = (await params).id;
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
-  const authorization = (await headers()).get('authorization');
-  const token = authorization?.split(' ')[1] ?? null;
 
-  let user: User | null;
-  let error: AuthError | null;
-  if (token) {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser(token));
-  } else {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser());
-  }
+  const { isSuccess, message, user, status } = await getUser(supabase);
 
-  if (error) {
-    return NextResponse.json({ message: error?.message }, { status: 401 });
-  }
-
-  if (!user) {
-    return NextResponse.json({ message: '로그인 후 이용해주세요' }, { status: 401 });
+  if (!isSuccess) {
+    return NextResponse.json({ message }, { status });
   }
 
   const { data: foundUser, error: foundUserError } = await supabase
@@ -99,29 +81,11 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ id: s
   const id = (await params).id;
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
-  const authorization = (await headers()).get('authorization');
-  const token = authorization?.split(' ')[1] ?? null;
 
-  let user: User | null;
-  let error: AuthError | null;
-  if (token) {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser(token));
-  } else {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser());
-  }
+  const { isSuccess, message, user, status: userStatus } = await getUser(supabase);
 
-  if (error) {
-    return NextResponse.json({ message: error?.message }, { status: 401 });
-  }
-
-  if (!user) {
-    return NextResponse.json({ message: '로그인 후 이용해주세요' }, { status: 401 });
+  if (!isSuccess) {
+    return NextResponse.json({ message }, { status: userStatus });
   }
 
   const { data: foundUser, error: foundUserError } = await supabase

--- a/src/app/api/moims/[id]/review/[reviewId]/route.ts
+++ b/src/app/api/moims/[id]/review/[reviewId]/route.ts
@@ -1,9 +1,10 @@
+import { getUser } from '@/app/api/auth/getUser';
 import { TMe } from '@/types/auth/auth.type';
 import { TReviewInput, TReviews } from '@/types/supabase/supabase-custom.type';
 import { mapMoimsToClient } from '@/utils/common/mapMoims';
 import { createClient } from '@/utils/supabase/server';
-import { AuthError, PostgrestError, User } from '@supabase/supabase-js';
-import { cookies, headers } from 'next/headers';
+import { PostgrestError } from '@supabase/supabase-js';
+import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 export async function PUT(
@@ -15,29 +16,11 @@ export async function PUT(
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
   const { review, rate }: TReviewInput = await req.json();
-  const authorization = (await headers()).get('authorization');
-  const token = authorization?.split(' ')[1] ?? null;
 
-  let user: User | null;
-  let error: AuthError | null;
-  if (token) {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser(token));
-  } else {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser());
-  }
+  const { isSuccess, message, user, status: userStatus } = await getUser(supabase);
 
-  if (error) {
-    return NextResponse.json({ message: error?.message }, { status: 401 });
-  }
-
-  if (!user) {
-    return NextResponse.json({ message: '유저가 없습니다' }, { status: 404 });
+  if (!isSuccess) {
+    return NextResponse.json({ message }, { status: userStatus });
   }
 
   const {
@@ -105,29 +88,11 @@ export async function DELETE(
   const reviewId = (await params).reviewId;
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
-  const authorization = (await headers()).get('authorization');
-  const token = authorization?.split(' ')[1] ?? null;
 
-  let user: User | null;
-  let error: AuthError | null;
-  if (token) {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser(token));
-  } else {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser());
-  }
+  const { isSuccess, message, user, status: userStatus } = await getUser(supabase);
 
-  if (error) {
-    return NextResponse.json({ message: error?.message }, { status: 401 });
-  }
-
-  if (!user) {
-    return NextResponse.json({ message: '유저가 없습니다' }, { status: 404 });
+  if (!isSuccess) {
+    return NextResponse.json({ message }, { status: userStatus });
   }
 
   const {

--- a/src/app/api/moims/[id]/review/route.ts
+++ b/src/app/api/moims/[id]/review/route.ts
@@ -1,9 +1,10 @@
+import { getUser } from '@/app/api/auth/getUser';
 import { TMe } from '@/types/auth/auth.type';
 import { TReviewInput, TReviews } from '@/types/supabase/supabase-custom.type';
 import { mapMoimsToClient } from '@/utils/common/mapMoims';
 import { createClient } from '@/utils/supabase/server';
-import { AuthError, PostgrestError, User } from '@supabase/supabase-js';
-import { cookies, headers } from 'next/headers';
+import { PostgrestError } from '@supabase/supabase-js';
+import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 // 해당 모임의 모든 리뷰 조회
@@ -47,29 +48,11 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
   const { review, rate }: TReviewInput = await req.json();
-  const authorization = (await headers()).get('authorization');
-  const token = authorization?.split(' ')[1] ?? null;
 
-  let user: User | null;
-  let error: AuthError | null;
-  if (token) {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser(token));
-  } else {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser());
-  }
+  const { isSuccess, message, user, status: userStatus } = await getUser(supabase);
 
-  if (error) {
-    return NextResponse.json({ message: error?.message }, { status: 401 });
-  }
-
-  if (!user) {
-    return NextResponse.json({ message: '로그인 후 이용해주세요' }, { status: 401 });
+  if (!isSuccess) {
+    return NextResponse.json({ message }, { status: userStatus });
   }
 
   const {

--- a/src/app/api/moims/my/route.ts
+++ b/src/app/api/moims/my/route.ts
@@ -2,37 +2,20 @@ import { TMe } from '@/types/auth/auth.type';
 import { TMoimClient, TMoimsJoined } from '@/types/supabase/supabase-custom.type';
 import { mapMoimsToClient } from '@/utils/common/mapMoims';
 import { createClient } from '@/utils/supabase/server';
-import { AuthError, PostgrestError, User } from '@supabase/supabase-js';
-import { cookies, headers } from 'next/headers';
+import { PostgrestError } from '@supabase/supabase-js';
+import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+import { getUser } from '../../auth/getUser';
 
 // 내가 만든 모임 조회
 export async function GET() {
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
-  const authorization = (await headers()).get('authorization');
-  const token = authorization?.split(' ')[1] ?? null;
 
-  let user: User | null;
-  let error: AuthError | null;
-  if (token) {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser(token));
-  } else {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser());
-  }
+  const { isSuccess, message, user, status: userStatus } = await getUser(supabase);
 
-  if (error) {
-    return NextResponse.json({ message: error?.message }, { status: 401 });
-  }
-
-  if (!user) {
-    return NextResponse.json({ message: '유저가 없습니다' }, { status: 404 });
+  if (!isSuccess) {
+    return NextResponse.json({ message }, { status: userStatus });
   }
 
   const { data: me, error: meError }: { data: TMe | null; error: PostgrestError | null } =

--- a/src/app/api/moims/participated/route.ts
+++ b/src/app/api/moims/participated/route.ts
@@ -5,37 +5,20 @@ import {
 } from '@/types/supabase/supabase-custom.type';
 import { mapMoimsToClient } from '@/utils/common/mapMoims';
 import { createClient } from '@/utils/supabase/server';
-import { AuthError, PostgrestError, User } from '@supabase/supabase-js';
-import { cookies, headers } from 'next/headers';
+import { PostgrestError } from '@supabase/supabase-js';
+import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+import { getUser } from '../../auth/getUser';
 
 // 내가 참여한 모임 조회
 export async function GET() {
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
-  const authorization = (await headers()).get('authorization');
-  const token = authorization?.split(' ')[1] ?? null;
 
-  let user: User | null;
-  let error: AuthError | null;
-  if (token) {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser(token));
-  } else {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser());
-  }
+  const { isSuccess, message, user, status: userStatus } = await getUser(supabase);
 
-  if (error) {
-    return NextResponse.json({ message: error?.message }, { status: 401 });
-  }
-
-  if (!user) {
-    return NextResponse.json({ message: '유저가 없습니다' }, { status: 404 });
+  if (!isSuccess) {
+    return NextResponse.json({ message }, { status: userStatus });
   }
 
   const {

--- a/src/app/api/reviews/my/route.ts
+++ b/src/app/api/reviews/my/route.ts
@@ -2,37 +2,20 @@ import { TMe } from '@/types/auth/auth.type';
 import { TReviewWithMoim, TReviewWithMoimClient } from '@/types/supabase/supabase-custom.type';
 import { mapMoimsToClient } from '@/utils/common/mapMoims';
 import { createClient } from '@/utils/supabase/server';
-import { AuthError, PostgrestError, User } from '@supabase/supabase-js';
-import { cookies, headers } from 'next/headers';
+import { PostgrestError } from '@supabase/supabase-js';
+import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+import { getUser } from '../../auth/getUser';
 
 // 내가 작성한 모든 리뷰 조회
 export async function GET() {
   const cookieStore = await cookies();
   const supabase = createClient(cookieStore);
-  const authorization = (await headers()).get('authorization');
-  const token = authorization?.split(' ')[1] ?? null;
 
-  let user: User | null;
-  let error: AuthError | null;
-  if (token) {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser(token));
-  } else {
-    ({
-      data: { user },
-      error,
-    } = await supabase.auth.getUser());
-  }
+  const { isSuccess, message, user, status: userStatus } = await getUser(supabase);
 
-  if (error) {
-    return NextResponse.json({ message: error?.message }, { status: 401 });
-  }
-
-  if (!user) {
-    return NextResponse.json({ message: '유저가 없습니다' }, { status: 404 });
+  if (!isSuccess) {
+    return NextResponse.json({ message }, { status: userStatus });
   }
 
   const {

--- a/src/utils/auth/auth-server.util.ts
+++ b/src/utils/auth/auth-server.util.ts
@@ -32,7 +32,7 @@ export const prefetchMe = async () => {
 
   await queryClient.prefetchQuery({
     queryKey: [QUERY_KEY_ME],
-    queryFn: () => getMe(accessToken),
+    queryFn: () => getMe(),
   });
   const me = await queryClient.getQueryData([QUERY_KEY_ME]);
   const dehydratedState = dehydrate(queryClient);


### PR DESCRIPTION
# Pull Request

## 📌 제목
access_token 만료에 따른 인증인가 에러 케이스 수정

---

## ✏️ 작업 내용 요약
> 엑세스 토큰이 만료되면, 저장시간이 긴 리프레시 토큰이 있음에도 supabase auth session 에러가 발생하는 문제 해결

## 📝 작업 내용 설명
> supabase 의 refresh_token 은 만료기간이 긴데도 자꾸 invalid refresh token, 400 이 리턴되는 문제를 발견했습니다.
> jwt가 제공되지 않으면 자동으로 현재 세션 정보를 사용하는 supabse.auth.getUser 의 작동방식을 이용해 대처했습니다.
> 1. 우선 jwt 없이 auth.getUser 를 실행하고, error 케이스 별로 대응하도록 하였습니다.
> 2. 1을 시도했는데 만약 Auth session missing 인 경우, jwt 를 사용해 다시 auth.getUser 를 시도하고,
> 3. 이렇게 했는데도 bad_jwt 이면 auth.refreshSession을 이용해 세션 갱신을 시도합니다.
> 4. 갱신이 성공하면 쿠키를 재설정하고 auth.getUser 를 다시 실행합니다.
> 5. 결과적으로 에러케이스라면 자동으로 세션이 갱신되면서 user를 찾아오게되고, 에러가 없다면 바로 user를 찾아오게 됩니다.

---

## ✅ 체크리스트
- [ ] 관련 Issue가 연결되었나요? (예: #123)
- [x] 새로운 기능이 문서화되었나요?
- [x] 작성한 코드가 로컬 환경에서 정상 동작하나요?

---
## ✅ 체크리스트:
- [x] 내 코드는 이 프로젝트의 컨벤션을 따릅니다.
- [x] 나는 PR 전에 내 코드를 검토했습니다.
- [x] 내 코드에 이해하기 어려운 부분에는 별도로 주석을 추가했습니다.
- [x] 내 변경 사항으로 인해 다른 요소들에 새로운 에러가 발생하지 않습니다.
